### PR TITLE
fix(dependencies): update forwardtests to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cryptellation/backtests v1.1.2
 	github.com/cryptellation/candlesticks v1.0.4
 	github.com/cryptellation/exchanges v1.1.1
-	github.com/cryptellation/forwardtests v1.1.1
+	github.com/cryptellation/forwardtests v1.2.0
 	github.com/cryptellation/go-clients v1.10.0
 	github.com/cryptellation/sma v1.0.6
 	github.com/cryptellation/ticks v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/cryptellation/exchanges v1.1.1 h1:bLXrfjKEAJGHasA8dROZTgiMQddRxZjdn6+
 github.com/cryptellation/exchanges v1.1.1/go.mod h1:2iyJgSid50L76UjS5gzV3hnCeq1DS4u/tkaJuq/toKY=
 github.com/cryptellation/forwardtests v1.1.1 h1:amKOjLEqMJ3PDzhMpLPzXEOPih12MiihSBYgBVueffo=
 github.com/cryptellation/forwardtests v1.1.1/go.mod h1:qG240vFOEmGbctY/T9jHcNEJjB92/xcEzo5sGPJhPNM=
+github.com/cryptellation/forwardtests v1.2.0 h1:QSGZFU8PWlkMHtqs9E0VVBrnKjcchwno+0zShTysucE=
+github.com/cryptellation/forwardtests v1.2.0/go.mod h1:lFvSePDBoMQYkUZUiYYuwWBwcUGalqPYSSlC0Gczi4Y=
 github.com/cryptellation/go-clients v1.10.0 h1:TvCnNwCtGMUNllkvDE8RWDUM3FcaJVXqK/pZs4Ls4L8=
 github.com/cryptellation/go-clients v1.10.0/go.mod h1:crrjE2PVi93qRB0yki4G0G1KjXyEUx4MyXNEVQpWDYc=
 github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1NRoRfWE=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/forwardtests** to version **v1.2.0**.

### Changes
- Updated dependency: `github.com/cryptellation/forwardtests`
- New version: `v1.2.0`

This update was automatically generated by DepSync.