### PR TITLE
fix(dependencies): update sma to v1.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cryptellation/exchanges v1.1.1
 	github.com/cryptellation/forwardtests v1.1.1
 	github.com/cryptellation/go-clients v1.10.0
-	github.com/cryptellation/sma v1.0.6
+	github.com/cryptellation/sma v1.1.0
 	github.com/cryptellation/ticks v1.2.1
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1N
 github.com/cryptellation/runtime v1.7.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
 github.com/cryptellation/sma v1.0.6 h1:Jtgg83vWDEIw24srmBz5eRig4nlBde7ueAHRnNizLYc=
 github.com/cryptellation/sma v1.0.6/go.mod h1:NJ3dHno2Ra3yVeIoFuSK4LTWiQ5E6uqRayemLZIvgwg=
+github.com/cryptellation/sma v1.1.0 h1:zZ3cgA8woBtrdupQKbC4eE+5n8QJ99l2wceFCoaG9hE=
+github.com/cryptellation/sma v1.1.0/go.mod h1:zGti7Eg3NtVaHGzqLaS9bCidMYnfuBuZD5gh/Qh84zM=
 github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11J6Vo=
 github.com/cryptellation/ticks v1.2.1/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/sma** to version **v1.1.0**.

### Changes
- Updated dependency: `github.com/cryptellation/sma`
- New version: `v1.1.0`

This update was automatically generated by DepSync.