### PR TITLE
chores(depsync): update github.com/cryptellation/timeseries to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 
 require (
 	github.com/cryptellation/runtime v1.7.0 // indirect
-	github.com/cryptellation/timeseries v1.1.0 // indirect
+	github.com/cryptellation/timeseries v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cryptellation/ticks v1.2.1 h1:onvm8kmEyBxK5ELWrzUqqCd8+6BT3LhPfBmUP11
 github.com/cryptellation/ticks v1.2.1/go.mod h1:tTMMu1U1e1I1J9Dp73KGh411TWrKcYmB4xORNJNPHtE=
 github.com/cryptellation/timeseries v1.1.0 h1:S5xFLGukQg+k22+L5151Na95+WjhhDKMK0hBkxfJYgo=
 github.com/cryptellation/timeseries v1.1.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
+github.com/cryptellation/timeseries v1.2.0 h1:x90TnFhE3H4zPWEgLLekPMG7t611cnFvNU9DnFyCiD0=
+github.com/cryptellation/timeseries v1.2.0/go.mod h1:SxqmKOjn/l5AXZGaLGA47oScXzpTcXtnmfom88uZdaY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/timeseries** to version **v1.2.0**.

### Changes
- Updated dependency: `github.com/cryptellation/timeseries`
- New version: `v1.2.0`

This update was automatically generated by DepSync.