### PR TITLE
chores(depsync): update github.com/cryptellation/go-clients to v1.12.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cryptellation/candlesticks v1.1.0
 	github.com/cryptellation/exchanges v1.1.1
 	github.com/cryptellation/forwardtests v1.2.0
-	github.com/cryptellation/go-clients v1.10.0
+	github.com/cryptellation/go-clients v1.12.1
 	github.com/cryptellation/sma v1.1.0
 	github.com/cryptellation/ticks v1.2.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cryptellation/forwardtests v1.2.0 h1:QSGZFU8PWlkMHtqs9E0VVBrnKjcchwno
 github.com/cryptellation/forwardtests v1.2.0/go.mod h1:lFvSePDBoMQYkUZUiYYuwWBwcUGalqPYSSlC0Gczi4Y=
 github.com/cryptellation/go-clients v1.10.0 h1:TvCnNwCtGMUNllkvDE8RWDUM3FcaJVXqK/pZs4Ls4L8=
 github.com/cryptellation/go-clients v1.10.0/go.mod h1:crrjE2PVi93qRB0yki4G0G1KjXyEUx4MyXNEVQpWDYc=
+github.com/cryptellation/go-clients v1.12.1 h1:D1kfIenyJIARsMjIlpMdqsQ958qN4S2Digelga/eQho=
+github.com/cryptellation/go-clients v1.12.1/go.mod h1:58O/3Whe9eT83FF3mnZ01Pj5IikmDsaCehA7Jy2DJ/Q=
 github.com/cryptellation/runtime v1.7.0 h1:8qCi8nBAsjQyF1a2makR1JIHuI9jSSJBWGS1NRoRfWE=
 github.com/cryptellation/runtime v1.7.0/go.mod h1:EFaH6DdIGe4eEPsapFKK5uIJZNII7MIGT2eWjl09RYU=
 github.com/cryptellation/runtime v1.8.0 h1:N0271FOlLh559BPSMTFMz+odDONbKnNZ6Yt1B4yHFos=


### PR DESCRIPTION
## Dependency Update

This merge request updates the dependency **github.com/cryptellation/go-clients** to version **v1.12.1**.

### Changes
- Updated dependency: `github.com/cryptellation/go-clients`
- New version: `v1.12.1`

This update was automatically generated by DepSync.